### PR TITLE
fix: Switched back to the openjdk base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8u372-alpine3.14-jre
+FROM openjdk:8-jre-alpine
 
 LABEL maintainer="devatherock@gmail.com>"
 


### PR DESCRIPTION
Done to get around git's safe.directory check