### PR TITLE
feat: Upgraded git cli to 2.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Upgraded spotless to `6.18.0`
 - Updated dockerhub readme in CI pipeline
 - Built a multi-arch docker image
-- Pinned git cli version to `2.20.4` in the docker image, to get around the `safe.directory` check
+- Pinned git cli version to the [highest available version](https://pkgs.alpinelinux.org/packages?name=git&branch=v3.12&repo=&arch=&maintainer=) less than [2.30.3](https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9) in the docker image, to get around the `safe.directory` check
 
 ## [3.0.0] - 2023-05-06
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 DOCKER_TAG=latest
+additional_gradle_args=
 
 clean:
 	./gradlew clean
 test:
 	sh unit-tests.sh	
 functional-test:
-	sh functional-tests.sh
+	sh functional-tests.sh "$(additional_gradle_args)"
 jar-build:
 	docker run --rm \
 	-v $(CURDIR):/work \

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ compileGroovy {
 
 test {
     useJUnitPlatform()
+    
+    systemProperty 'skip.pull', System.properties['skip.pull']
 }
 
 ext.jacoco = [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apk --update add openssh
 
 # Install git. Pinned git version to get around the safe.directory check
-RUN apk add git=2.20.4-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main
+RUN apk add git=2.26.3-r1 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main
 
 COPY SyncGitRepos.jar /scripts/
 COPY docker/entry-point.sh /scripts/

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+additional_gradle_args=$1
+
 mkdir git-sync-test
 cp -r * git-sync-test
 cp -r .git git-sync-test
 cd git-sync-test
 export CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
 git remote set-url origin "https://git-sync-token:$GIT_TOKEN@github.com/devatherock/git-sync.git"
-./gradlew test --tests '*SyncGitReposDockerSpec*' -x jacocoTestCoverageVerification
+./gradlew test --tests '*SyncGitReposDockerSpec*' -x jacocoTestCoverageVerification ${additional_gradle_args}
 exit_code=$?
 cd ..
 rm -rf git-sync-test

--- a/src/test/groovy/io/github/devatherock/gitsync/docker/SyncGitReposDockerSpec.groovy
+++ b/src/test/groovy/io/github/devatherock/gitsync/docker/SyncGitReposDockerSpec.groovy
@@ -37,7 +37,10 @@ class SyncGitReposDockerSpec extends Specification {
 
     void setupSpec() {
         System.setProperty('java.util.logging.SimpleFormatter.format', '%5$s%n')
-        ProcessUtil.executeCommand("docker pull ${dockerImage}")
+
+        if (!Boolean.getBoolean('skip.pull')) {
+            ProcessUtil.executeCommand("docker pull ${dockerImage}")
+        }
     }
 
     void setup() {


### PR DESCRIPTION
2.26.3 was the highest available version below 2.30.3 which first introduced the safe.directory check